### PR TITLE
All feedstocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,12 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+node_attrs/*
+graph.json
+pr_json/*
+pr_status/*
+status/*
+feedstocks/*
+coverage.xml
+.coverage.*

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -3,15 +3,16 @@ This code is a rework of
 https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/all_feedstocks.py
 for use by nsls-ii-forge's own auto-tick bot.
 '''
-import github3
-import os
 import datetime
 import logging
+import netrc
+
+import github3
 
 logger = logging.getLogger(__name__)
 
 
-def get_all_feedstocks_from_github(organization, **kwargs):
+def get_all_feedstocks_from_github(organization, username=None, token=None):
     '''
     Gets all public feedstock repository names from the GitHub organization
     (e.g. nsls-ii-forge).
@@ -32,15 +33,10 @@ def get_all_feedstocks_from_github(organization, **kwargs):
     names: list
         List of repository names that end with '-feedstock' (stripped).
     '''
-    if 'username' not in kwargs:
-        username = os.environ['USERNAME']
-    else:
-        username = kwargs['username']
-    if 'password' not in kwargs:
-        password = os.environ['PASSWORD']
-    else:
-        password = kwargs['password']
-    gh = github3.login(username, password)
+    if username is None:
+        netrc_file = netrc.netrc()
+        username, _, token = netrc_file.hosts['github.com']
+    gh = github3.login(username, token)
     org = gh.organization(organization)
     repos = org.repositories()
     names = []
@@ -65,42 +61,45 @@ def get_all_feedstocks_from_github(organization, **kwargs):
     return names
 
 
-def get_all_feedstocks(organization, username=None, password=None, cached=False):
+def get_all_feedstocks(organization=None, cached=False, **kwargs):
     '''
     Gets all feedstocks either from GitHub or from names.txt if flag is specified.
 
     Parameters
     ----------
-    organization: str
-        Name of organization on GitHub.
-    username: str, optional
-        Name of user on GitHub for authentication.
-        Uses environment variable if not specified.
-    password: str, optional
-        Password of user on GitHub for authentication.
-        Uses environment variable if username not specified.
+    organization: str, optional
+        Name of organization on GitHub. Optional only if cached = True.
     cached: bool, optional
         Specified if client wants to take repository names from names.txt.
+    kwargs: dict, optional
+        Username and token may be specified here for authentication.
 
     Returns
     -------
     names: list or None
         List of repository names that end with '-feedstock' (stripped).
-        None if no organization or username is specified.
+        None if no organization or username is specified and cached = False.
     '''
     if cached:
         logger.info("reading names")
         with open("names.txt", "r") as f:
             names = f.read().split()
         return names
-    if organization == '':
+    if organization is None:
         logger.info("No GitHub organization specified.")
         return None
-    names = get_all_feedstocks_from_github(organization, username=username, password=password)
+    if 'username' in kwargs and 'token' in kwargs:
+        username = kwargs['username']
+        token = kwargs['token']
+    else:
+        username = None
+        token = None
+    names = get_all_feedstocks_from_github(organization, username=username, token=token)
     return names
 
 
 def main(args=None):
+    # TODO: move organization to global CONFIG file
     organization = 'nsls-ii-forge'
     names = get_all_feedstocks(organization, cached=False)
     # write each repository name to a file

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -8,8 +8,21 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def get_all_feedstocks_from_github() -> List[str]:
-    org = github3.organization('nsls-ii-forge')
+def get_all_feedstocks_from_github(organization):
+    '''
+    Gets all public feedstock repository names from the nsls-ii-forge organization.
+    
+    Parameters
+    ----------
+    organization : str
+        Name of organization on GitHub.
+
+    Returns
+    -------
+    names : List
+        List of repository names that end with '-feedstock' (stripped).
+    '''
+    org = github3.organization(organization)
     repos = org.repositories()
     names = []
     try:
@@ -33,7 +46,22 @@ def get_all_feedstocks_from_github() -> List[str]:
     return names
 
 
-def get_all_feedstocks(cached: bool = False) -> List[str]:
+def get_all_feedstocks(organization, cached=False):
+    '''
+    Gets all feedstocks either from GitHub or from names.txt if flag is specified.
+
+    Parameters
+    ----------
+    organization : str
+        Name of organization on GitHub.
+    cached : bool
+        Specified if client wants to take repository names from names.txt.
+
+    Returns
+    -------
+    names : List
+        List of repository names that end with '-feedstock' (stripped).
+    '''
     if cached:
         logger.info("reading names")
         with open("names.txt", "r") as f:
@@ -44,7 +72,8 @@ def get_all_feedstocks(cached: bool = False) -> List[str]:
     return names
 
 
-def main(args: Any = None) -> None:
+def main(args=None):
+    # see if json exists for active feedstocks
     try:
         logger.info("fetching active feedstocks from admin-migrations")
         r = requests.get(
@@ -64,6 +93,7 @@ def main(args: Any = None) -> None:
         with open("names_are_active.flag", "w") as fp:
             fp.write("no")
 
+    # write each repository name to a file
     with open("names.txt", "w") as f:
         for name in names:
             f.write(name)

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -12,7 +12,7 @@ import github3
 logger = logging.getLogger(__name__)
 
 
-def get_all_feedstocks_from_github(organization, username=None, token=None):
+def get_all_feedstocks_from_github(organization=None, username=None, token=None):
     '''
     Gets all public feedstock repository names from the GitHub organization
     (e.g. nsls-ii-forge).
@@ -30,9 +30,13 @@ def get_all_feedstocks_from_github(organization, username=None, token=None):
 
     Returns
     -------
-    names: list
+    names: list, None
         List of repository names that end with '-feedstock' (stripped).
+        None if no organization is specified.
     '''
+    if organization is None:
+        logger.critical('No GitHub organization sepcified.')
+        return None
     if username is None:
         netrc_file = netrc.netrc()
         username, _, token = netrc_file.hosts['github.com']
@@ -61,18 +65,17 @@ def get_all_feedstocks_from_github(organization, username=None, token=None):
     return names
 
 
-def get_all_feedstocks(organization=None, cached=False, **kwargs):
+def get_all_feedstocks(cached=False, **kwargs):
     '''
     Gets all feedstocks either from GitHub or from names.txt if flag is specified.
 
     Parameters
     ----------
-    organization: str, optional
-        Name of organization on GitHub. Optional only if cached = True.
     cached: bool, optional
         Specified if client wants to take repository names from names.txt.
     kwargs: dict, optional
-        Username and token may be specified here for authentication.
+        Organization, username and token should be specified here for authentication
+        if cached = False.
 
     Returns
     -------
@@ -85,23 +88,14 @@ def get_all_feedstocks(organization=None, cached=False, **kwargs):
         with open("names.txt", "r") as f:
             names = f.read().split()
         return names
-    if organization is None:
-        logger.info("No GitHub organization specified.")
-        return None
-    if 'username' in kwargs and 'token' in kwargs:
-        username = kwargs['username']
-        token = kwargs['token']
-    else:
-        username = None
-        token = None
-    names = get_all_feedstocks_from_github(organization, username=username, token=token)
+    names = get_all_feedstocks_from_github(**kwargs)
     return names
 
 
 def main(args=None):
     # TODO: move organization to global CONFIG file
     organization = 'nsls-ii-forge'
-    names = get_all_feedstocks(organization, cached=False)
+    names = get_all_feedstocks(cached=False, organization=organization)
     # write each repository name to a file
     with open("names.txt", "w") as f:
         for name in names:

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -1,10 +1,9 @@
-import datetime
-
 import requests
 import github3
 import logging
 
 logger = logging.getLogger(__name__)
+
 
 def get_all_feedstocks_from_github(organization):
     '''
@@ -35,10 +34,7 @@ def get_all_feedstocks_from_github(organization):
         msg = ["Github rate limited. "]
         c = org.ratelimit_remaining()
         if c == 0:
-            msg.append("API timeout, API returns at")
-            msg.append(
-                datetime.datetime.utcfromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            )
+            msg.append("API timeout.")
         logger.warning(" ".join(msg))
         raise
     return names

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -1,3 +1,8 @@
+'''
+This code is a rework of
+https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/all_feedstocks.py
+for use by nsls-ii-forge's own auto-tick bot.
+'''
 import requests
 import github3
 import logging
@@ -7,17 +12,17 @@ logger = logging.getLogger(__name__)
 
 def get_all_feedstocks_from_github(organization):
     '''
-    Gets all public feedstock repository names from the nsls-ii-forge organization.
-
+    Gets all public feedstock repository names from the GitHub organization
+    (e.g. nsls-ii-forge).
 
     Parameters
     ----------
-    organization : str
+    organization: str
         Name of organization on GitHub.
 
     Returns
     -------
-    names : List
+    names: list
         List of repository names that end with '-feedstock' (stripped).
     '''
     org = github3.organization(organization)
@@ -46,22 +51,25 @@ def get_all_feedstocks(organization, cached=False):
 
     Parameters
     ----------
-    organization : str
+    organization: str
         Name of organization on GitHub.
-    cached : bool
+    cached: bool, optional
         Specified if client wants to take repository names from names.txt.
 
     Returns
     -------
-    names : List
+    names: list or None
         List of repository names that end with '-feedstock' (stripped).
+        None if no organization or username is specified.
     '''
     if cached:
         logger.info("reading names")
         with open("names.txt", "r") as f:
             names = f.read().split()
         return names
-
+    if organization == '':
+        logger.info("No GitHub organization specified.")
+        return None
     names = get_all_feedstocks_from_github(organization)
     return names
 

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -1,0 +1,74 @@
+import datetime
+import os
+from typing import Any, List
+
+import requests
+import github3
+import logging
+
+logger = logging.getLogger(__name__)
+
+def get_all_feedstocks_from_github() -> List[str]:
+    org = github3.organization('nsls-ii-forge')
+    repos = org.repositories()
+    names = []
+    try:
+        for repo in repos:
+            name = repo.name
+            if name.endswith("-feedstock"):
+                name = name.split("-feedstock")[0]
+                logger.info(name)
+                names.append(name)
+    except github3.GitHubError:
+        msg = ["Github rate limited. "]
+        c = gh.rate_limit()["resources"]["core"]
+        if c["remaining"] == 0:
+            ts = c["reset"]
+            msg.append("API timeout, API returns at")
+            msg.append(
+                datetime.datetime.utcfromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            )
+        logger.warning(" ".join(msg))
+        raise
+    return names
+
+
+def get_all_feedstocks(cached: bool = False) -> List[str]:
+    if cached:
+        logger.info("reading names")
+        with open("names.txt", "r") as f:
+            names = f.read().split()
+        return names
+
+    names = get_all_feedstocks_from_github()
+    return names
+
+
+def main(args: Any = None) -> None:
+    try:
+        logger.info("fetching active feedstocks from admin-migrations")
+        r = requests.get(
+            "https://raw.githubusercontent.com/nsls-ii-forge/admin-migrations/"
+            "master/data/all_feedstocks.json"
+        )
+        if r.status_code != 200:
+            r.raise_for_status()
+
+        names = r.json()["active"]
+        with open("names_are_active.flag", "w") as fp:
+            fp.write("yes")
+    except Exception as e:
+        logger.critical("admin-migrations all feedstocks failed: %s", repr(e))
+        logger.critical("defaulting to the local version")
+        names = get_all_feedstocks(cached=False)
+        with open("names_are_active.flag", "w") as fp:
+            fp.write("no")
+
+    with open("names.txt", "w") as f:
+        for name in names:
+            f.write(name)
+            f.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -1,6 +1,4 @@
 import datetime
-import os
-from typing import Any, List
 
 import requests
 import github3
@@ -11,7 +9,8 @@ logger = logging.getLogger(__name__)
 def get_all_feedstocks_from_github(organization):
     '''
     Gets all public feedstock repository names from the nsls-ii-forge organization.
-    
+
+
     Parameters
     ----------
     organization : str
@@ -34,9 +33,8 @@ def get_all_feedstocks_from_github(organization):
                 names.append(name)
     except github3.GitHubError:
         msg = ["Github rate limited. "]
-        c = gh.rate_limit()["resources"]["core"]
-        if c["remaining"] == 0:
-            ts = c["reset"]
+        c = org.ratelimit_remaining()
+        if c == 0:
             msg.append("API timeout, API returns at")
             msg.append(
                 datetime.datetime.utcfromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -21,7 +21,7 @@ def get_all_feedstocks_from_github(organization, username='', password=''):
     organization: str
         Name of organization on GitHub.
     username: str, optional
-        Name of user on GitHub for authentication. 
+        Name of user on GitHub for authentication.
         Uses environment variables if not specified.
     password: str, optional
         Password of user on GitHub for authentication.
@@ -69,7 +69,7 @@ def get_all_feedstocks(organization, username='', password='', cached=False):
     organization: str
         Name of organization on GitHub.
     username: str, optional
-        Name of user on GitHub for authentication. 
+        Name of user on GitHub for authentication.
         Uses environment variable if not specified.
     password: str, optional
         Password of user on GitHub for authentication.

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -68,11 +68,12 @@ def get_all_feedstocks(organization, cached=False):
             names = f.read().split()
         return names
 
-    names = get_all_feedstocks_from_github()
+    names = get_all_feedstocks_from_github(organization)
     return names
 
 
 def main(args=None):
+    organization = 'nsls-ii-forge'
     # see if json exists for active feedstocks
     try:
         logger.info("fetching active feedstocks from admin-migrations")
@@ -89,7 +90,7 @@ def main(args=None):
     except Exception as e:
         logger.critical("admin-migrations all feedstocks failed: %s", repr(e))
         logger.critical("defaulting to the local version")
-        names = get_all_feedstocks(cached=False)
+        names = get_all_feedstocks(organization, cached=False)
         with open("names_are_active.flag", "w") as fp:
             fp.write("no")
 

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -3,7 +3,6 @@ This code is a rework of
 https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/all_feedstocks.py
 for use by nsls-ii-forge's own auto-tick bot.
 '''
-import requests
 import github3
 import logging
 
@@ -76,26 +75,7 @@ def get_all_feedstocks(organization, cached=False):
 
 def main(args=None):
     organization = 'nsls-ii-forge'
-    # see if json exists for active feedstocks
-    try:
-        logger.info("fetching active feedstocks from admin-migrations")
-        r = requests.get(
-            "https://raw.githubusercontent.com/nsls-ii-forge/admin-migrations/"
-            "master/data/all_feedstocks.json"
-        )
-        if r.status_code != 200:
-            r.raise_for_status()
-
-        names = r.json()["active"]
-        with open("names_are_active.flag", "w") as fp:
-            fp.write("yes")
-    except Exception as e:
-        logger.critical("admin-migrations all feedstocks failed: %s", repr(e))
-        logger.critical("defaulting to the local version")
-        names = get_all_feedstocks(organization, cached=False)
-        with open("names_are_active.flag", "w") as fp:
-            fp.write("no")
-
+    names = get_all_feedstocks(organization, cached=False)
     # write each repository name to a file
     with open("names.txt", "w") as f:
         for name in names:

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_all_feedstocks_from_github(organization, username='', password=''):
+def get_all_feedstocks_from_github(organization, **kwargs):
     '''
     Gets all public feedstock repository names from the GitHub organization
     (e.g. nsls-ii-forge).
@@ -32,10 +32,15 @@ def get_all_feedstocks_from_github(organization, username='', password=''):
     names: list
         List of repository names that end with '-feedstock' (stripped).
     '''
-    if username == '':
-        gh = github3.login(os.environ['USERNAME'], os.environ['PASSWORD'])
+    if 'username' not in kwargs:
+        username = os.environ['USERNAME']
     else:
-        gh = github3.login(username, password)
+        username = kwargs['username']
+    if 'password' not in kwargs:
+        password = os.environ['PASSWORD']
+    else:
+        password = kwargs['password']
+    gh = github3.login(username, password)
     org = gh.organization(organization)
     repos = org.repositories()
     names = []
@@ -60,7 +65,7 @@ def get_all_feedstocks_from_github(organization, username='', password=''):
     return names
 
 
-def get_all_feedstocks(organization, username='', password='', cached=False):
+def get_all_feedstocks(organization, username=None, password=None, cached=False):
     '''
     Gets all feedstocks either from GitHub or from names.txt if flag is specified.
 
@@ -91,7 +96,7 @@ def get_all_feedstocks(organization, username='', password='', cached=False):
     if organization == '':
         logger.info("No GitHub organization specified.")
         return None
-    names = get_all_feedstocks_from_github(organization, username, password)
+    names = get_all_feedstocks_from_github(organization, username=username, password=password)
     return names
 
 
@@ -101,8 +106,7 @@ def main(args=None):
     # write each repository name to a file
     with open("names.txt", "w") as f:
         for name in names:
-            f.write(name)
-            f.write("\n")
+            f.write(f'{name}\n')
 
 
 if __name__ == "__main__":

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -23,10 +23,10 @@ def get_all_feedstocks_from_github(organization=None, username=None, token=None)
         Name of organization on GitHub.
     username: str, optional
         Name of user on GitHub for authentication.
-        Uses environment variables if not specified.
+        Uses value from ~/.netrc if not specified.
     password: str, optional
         Password of user on GitHub for authentication.
-        Uses environment variables if not specified.
+        Uses value from ~/.netrc if not specified.
 
     Returns
     -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # List required packages in this file, one per line.
-github3
+github3.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # List required packages in this file, one per line.
+github3


### PR DESCRIPTION
Added file `all_feedstocks.py` which lists all the names of the feedstock repositories in nsls-ii-forge and places them in names.txt.

Also added to `.gitignore` for future work.