### PR TITLE
Clone feedstocks functionality added to all_feedstocks.py

### DIFF
--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -109,8 +109,31 @@ def clone_all_feedstocks(organization, feedstocks_dir):
     feedstocks_dir: str
         Path to local directory to place cloned feedstocks.
     '''
-    feedstocks.clone_all_feedstocks(gh_org=organization,
-                                    feedstocks_dir=feedstocks_dir)
+    feedstocks.clone_all(gh_org=organization,
+                         feedstocks_dir=feedstocks_dir)
+
+
+def _clone_all_handle_args(args):
+    print(f'Cloning feestocks from {args.organization}...')
+    clone_all_feedstocks(args.organization, args.feedstocks_dir)
+
+
+def _list_all_handle_args(args):
+    if not args.cached and args.organization is None:
+        print('ERROR: Organization must be specified unless '
+              'cached flag is used. Use -h or --help for help.')
+        return
+    names = get_all_feedstocks(cached=args.cached,
+                               organization=args.organization,
+                               username=args.username,
+                               token=args.token,
+                               filepath=args.filepath)
+    if args.write:
+        _write_list_to_file(names, args.filepath, sort=True)
+
+    for name in sorted(names):
+        print(name)
+    print(f'Total feedstocks: {len(names)}')
 
 
 def main(args=None):

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -1,6 +1,6 @@
 '''
 This code is a rework of
-https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/all_feedstocks.py
+https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/all_feedstocks.py.
 for use by nsls-ii-forge's own auto-tick bot.
 '''
 import datetime
@@ -8,6 +8,7 @@ import logging
 import netrc
 
 import github3
+from conda_smithy import feedstocks
 
 from nsls2forge_utils.io import _write_list_to_file, read_file_to_list
 
@@ -97,12 +98,28 @@ def get_all_feedstocks(cached=False, filepath='names.txt', **kwargs):
     return names
 
 
+def clone_all_feedstocks(organization, feedstocks_dir):
+    '''
+    Clones all feedstock repos from organization to local feedstocks_dir.
+
+    Parameters
+    ----------
+    organization: str
+        GitHub organization to clone feedstock repos from.
+    feedstocks_dir: str
+        Path to local directory to place cloned feedstocks.
+    '''
+    feedstocks.clone_all_feedstocks(gh_org=organization,
+                                    feedstocks_dir=feedstocks_dir)
+
+
 def main(args=None):
     # TODO: move organization to global CONFIG file
     organization = 'nsls-ii-forge'
     names = get_all_feedstocks(cached=False, organization=organization)
     # write each repository name to a file
     _write_list_to_file(names, 'names.txt', sort=True)
+    clone_all_feedstocks(organization, './feedstocks')
 
 
 if __name__ == "__main__":

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -130,10 +130,11 @@ def _list_all_handle_args(args):
                                username=args.username,
                                token=args.token,
                                filepath=args.filepath)
+    names = sorted(names)
     if args.write:
-        _write_list_to_file(names, args.filepath, sort=True)
+        _write_list_to_file(names, args.filepath, sort=False)
 
-    for name in sorted(names):
+    for name in names:
         print(name)
     print(f'Total feedstocks: {len(names)}')
 

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -1,7 +1,8 @@
 '''
 This code is a rework of
-https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/all_feedstocks.py.
-for use by nsls-ii-forge's own auto-tick bot.
+https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/all_feedstocks.py
+This version was not importable so the functions had to be copied here.
+We will be importing conda-smithy functionality.
 '''
 import datetime
 import logging
@@ -101,6 +102,7 @@ def get_all_feedstocks(cached=False, filepath='names.txt', **kwargs):
 def clone_all_feedstocks(organization, feedstocks_dir):
     '''
     Clones all feedstock repos from organization to local feedstocks_dir.
+    Uses conda-smithy's clone all utility.
 
     Parameters
     ----------

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from .check_results import check_conda_channels, check_package_version
 from .all_feedstocks import _list_all_handle_args, _clone_all_handle_args
@@ -67,10 +68,12 @@ def all_feedstocks():
     # Give GitHub username and token
     list_parser.add_argument('-u', '--username', dest='username',
                              default=None, type=str,
-                             help=('GitHub username for authentication'))
+                             help=('GitHub username for authentication. '
+                                   'Uses ~/.netrc by default'))
     list_parser.add_argument('-t', '--token', dest='token',
                              default=None, type=str,
-                             help=('GitHub token for authentication'))
+                             help=('GitHub token for authentication. '
+                                   'Uses ~/.netrc by default'))
 
     # Set file path
     list_parser.add_argument('-f', '--filepath', dest='filepath',
@@ -98,10 +101,17 @@ def all_feedstocks():
     # Set feedstock dir to clone to
     clone_parser.add_argument('-f', '--feedstocks-dir', dest='feedstocks_dir',
                               default='./feedstocks', type=str,
-                              help=('directory to clone feedstocks to'))
+                              help=('Directory to clone feedstocks to. Default is '
+                                    './feedstocks'))
 
     # Set function to handle arguments
     clone_parser.set_defaults(func=_clone_all_handle_args)
 
     args = parser.parse_args()
+
+    # check for no arguments and print help
+    if len(sys.argv) == 1:
+        parser.print_help()
+        parser.exit(message='Please specify organization and sub-command...\n')
+
     args.func(args)

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -76,7 +76,7 @@ def all_feedstocks():
     # write to file flag
     parser.add_argument('-w', '--write', dest='write',
                         action='store_true',
-                        help=('Writes the feedstock names to a file.'))
+                        help=('writes the feedstock names to a file.'))
 
     # Set cached to true
     parser.add_argument('-c', '--cached', dest='cached',

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -1,8 +1,7 @@
 import argparse
 
 from .check_results import check_conda_channels, check_package_version
-from .all_feedstocks import get_all_feedstocks
-from .io import _write_list_to_file
+from .all_feedstocks import _list_all_handle_args, _clone_all_handle_args
 
 
 def check_results():
@@ -52,7 +51,7 @@ def check_results():
 
 def all_feedstocks():
     parser = argparse.ArgumentParser(
-        description=('Retrieve all feedstock repositories from cache or GitHub '))
+        description=('List/Clone all feedstock repositories from cache or GitHub '))
 
     # Give GitHub organization name
     parser.add_argument('-o', '--organization', dest='organization',
@@ -60,43 +59,49 @@ def all_feedstocks():
                         help=('GitHub organization to get feedstocks from '
                               '(must be specified if not cached)'))
 
+    subparsers = parser.add_subparsers(help='sub-command help')
+    # Subparser for 'list' command
+    list_parser = subparsers.add_parser('list',
+                                        help=('lists all feedstocks from cache '
+                                              'or GitHub'))
     # Give GitHub username and token
-    parser.add_argument('-u', '--username', dest='username',
-                        default=None, type=str,
-                        help=('GitHub username for authentication'))
-    parser.add_argument('-t', '--token', dest='token',
-                        default=None, type=str,
-                        help=('GitHub token for authentication'))
+    list_parser.add_argument('-u', '--username', dest='username',
+                             default=None, type=str,
+                             help=('GitHub username for authentication'))
+    list_parser.add_argument('-t', '--token', dest='token',
+                             default=None, type=str,
+                             help=('GitHub token for authentication'))
 
     # Set file path
-    parser.add_argument('-f', '--filepath', dest='filepath',
-                        default='names.txt', type=str,
-                        help=('filepath to write feedstock names to '
-                              '(default is names.txt)'))
+    list_parser.add_argument('-f', '--filepath', dest='filepath',
+                             default='names.txt', type=str,
+                             help=('filepath to write feedstock names to '
+                                   '(default is names.txt)'))
     # write to file flag
-    parser.add_argument('-w', '--write', dest='write',
-                        action='store_true',
-                        help=('writes the feedstock names to a file.'))
+    list_parser.add_argument('-w', '--write', dest='write',
+                             action='store_true',
+                             help=('writes the feedstock names to a file.'))
 
     # Set cached to true
-    parser.add_argument('-c', '--cached', dest='cached',
-                        action='store_true',
-                        help=('read the names of feedstocks from the cache'))
+    list_parser.add_argument('-c', '--cached', dest='cached',
+                             action='store_true',
+                             help=('read the names of feedstocks from the cache'))
+    # Set function to handle arguments
+    list_parser.set_defaults(func=_list_all_handle_args)
+
+    # Subparser for 'clone' command
+    clone_parser = subparsers.add_parser('clone',
+                                         help=('Clones all feedstocks from GitHub. '
+                                               'Uses ~/.conda-smithy/github.token for '
+                                               'authentication'))
+
+    # Set feedstock dir to clone to
+    clone_parser.add_argument('-f', '--feedstocks-dir', dest='feedstocks_dir',
+                              default='./feedstocks', type=str,
+                              help=('directory to clone feedstocks to'))
+
+    # Set function to handle arguments
+    clone_parser.set_defaults(func=_clone_all_handle_args)
 
     args = parser.parse_args()
-
-    if not args.cached and args.organization is None:
-        parser.exit(message=('ERROR: Organization must be specified unless '
-                             'cached flag is used. Use -h or --help for help.\n'))
-
-    names = get_all_feedstocks(cached=args.cached,
-                               organization=args.organization,
-                               username=args.username,
-                               token=args.token,
-                               filepath=args.filepath)
-    if args.write:
-        _write_list_to_file(names, args.filepath, sort=True)
-
-    for name in sorted(names):
-        print(name)
-    print(f'Total feedstocks: {len(names)}')
+    args.func(args)


### PR DESCRIPTION
Changes made:

- Using conda-smithy/feedstocks.py `clone_all()` function with wrapper
- Changed `cli.py` to include subparsers to better differentiate args
- Created functions to handle args