### PR TITLE
Dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ feedstocks/*
 coverage.xml
 .coverage.*
 miniconda.sh
+README.md

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -3,6 +3,7 @@ import sys
 
 from .check_results import check_conda_channels, check_package_version
 from .all_feedstocks import _list_all_handle_args, _clone_all_handle_args
+from .dashboard import create_dashboard
 
 
 def check_results():
@@ -123,3 +124,21 @@ def all_feedstocks():
         parser.exit(message='Please specify organization and sub-command...\n')
 
     args.func(args)
+
+
+def dashboard():
+    parser = argparse.ArgumentParser(
+        description='Create a dashboard of feedstocks belonging to nsls-ii-forge')
+
+    parser.add_argument('-n', '--names', dest='names',
+                        default=None, type=str,
+                        help=('filepath to text file containing feedstock repo names '
+                              'without the -feedstock suffix (optional)'))
+
+    parser.add_argument('-w', '--write', dest='write',
+                        default='README.md', type=str,
+                        help=('filepath to markdown file to write output to'))
+
+    args = parser.parse_args()
+
+    create_dashboard(names=args.names)

--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -4,39 +4,60 @@ https://github.com/xpdAcq/mission-control/blob/master/tools/update_readme.py
 This version was not importable so the
 functions had to be re-implemented here.
 """
-
 from nsls2forge_utils.all_feedstocks import get_all_feedstocks
+from nsls2forge_utils.io import read_file_to_list
 
-# TODO: Azure Pipeline direct pipeline link
-# TODO: Add codecov badge if available
-main_format = dict(
-    build='[![Build Status](https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/{name}-feedstock)]'
-          '(https://dev.azure.com/nsls2forge/nsls2forge/_build)',
-    health='[![Code Health](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master/'
-           'landscape.svg?style=flat)](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master)',
-    cf_version='[![Anaconda-Server Badge](https://anaconda.org/conda-forge/{name}/badges/version.svg)]'
-               '(https://anaconda.org/conda-forge/{name})',
-    nsls_version='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/version.svg)]'
-                 '(https://anaconda.org/nsls2forge/{name})',
-    downloads='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/downloads.svg)]'
-              '(https://anaconda.org/nsls2forge/{name})')
 
-row_string = '''|[{name}](https://github.com/nsls-ii-forge/{name}-feedstock)|{build}|{health}
-|{cf_version} <br/> {nsls_version}|{downloads}|\n'''
-description = '''# Project Management
-Releases, Installers, Specs, and more!
-'''
-header = '''# {} Packages Build status\n
-| Repo | Build | Health | CF Version <br/> NSLS Version | Downloads|
-|:-------:|:-----:|:------:|:------:|:------:|
-'''
+def create_dashboard(names=None, write_to='README.md'):
+    '''
+    Creates a table of packages with their build status, health, conda-forge version,
+    nsls2forge version, and number of downloads from nsls2forge.
+    Feedstocks must be from nsls-ii-forge GitHub organization.
 
-out = description
-name = 'Feedstock'
-pkgs = sorted(get_all_feedstocks(organization='nsls-ii-forge'))
-out += header.format(name)
-for pkg in pkgs:
-    tmp = row_string.format(**main_format, name=pkg)
-    out += tmp.format(name=pkg)
-# with open('../README.md', 'w') as f:
-#     f.write(out)
+    Parameters
+    ----------
+    names: str, optional
+        filepath to text file containing feedstock repo names
+        without the -feedstock suffix
+    write_to: str, optional
+        filepath to markdown file to write output to
+    '''
+    # TODO: Azure Pipeline direct pipeline link
+    # TODO: Add codecov badge if available
+    main_format = dict(
+      build='[![Build Status](https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/{name}-feedstock)]'
+            '(https://dev.azure.com/nsls2forge/nsls2forge/_build)',
+      health='[![Code Health](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master/'
+             'landscape.svg?style=flat)](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master)',
+      cf_version='[![Anaconda-Server Badge](https://anaconda.org/conda-forge/{name}/badges/version.svg)]'
+                 '(https://anaconda.org/conda-forge/{name})',
+      nsls_version='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/version.svg)]'
+                   '(https://anaconda.org/nsls2forge/{name})',
+      downloads='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/downloads.svg)]'
+                '(https://anaconda.org/nsls2forge/{name})')
+
+    row_string = '''|[{name}](https://github.com/nsls-ii-forge/{name}-feedstock)|{build}|{health}
+    |{cf_version} <br/> {nsls_version}|{downloads}|\n'''
+    description = '''# Project Management
+    Releases, Installers, Specs, and more!
+    '''
+    header = '''# Feedstock Packages Build status\n
+    | Repo | Build | Health | CF Version <br/> NSLS Version | Downloads|
+    |:-------:|:-----:|:------:|:------:|:------:|
+    '''
+
+    out = description
+    if names is None:
+        pkgs = sorted(get_all_feedstocks(organization='nsls-ii-forge'))
+    else:
+        pkgs = sorted(read_file_to_list(names))
+    out += header
+    for pkg in pkgs:
+        tmp = row_string.format(**main_format, name=pkg)
+        out += tmp.format(name=pkg)
+    with open(write_to, 'w') as f:
+        f.write(out)
+
+
+if __name__ == '__main__':
+    create_dashboard()

--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -1,0 +1,42 @@
+"""
+This code is a rework of
+https://github.com/xpdAcq/mission-control/blob/master/tools/update_readme.py
+This version was not importable so the
+functions had to be re-implemented here.
+"""
+
+from nsls2forge_utils.all_feedstocks import get_all_feedstocks
+
+# TODO: Azure Pipeline direct pipeline link
+# TODO: Add codecov badge if available
+main_format = dict(
+    build='[![Build Status](https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/{name}-feedstock)]'
+          '(https://dev.azure.com/nsls2forge/nsls2forge/_build)',
+    health='[![Code Health](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master/'
+           'landscape.svg?style=flat)](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master)',
+    cf_version='[![Anaconda-Server Badge](https://anaconda.org/conda-forge/{name}/badges/version.svg)]'
+               '(https://anaconda.org/conda-forge/{name})',
+    nsls_version='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/version.svg)]'
+                 '(https://anaconda.org/nsls2forge/{name})',
+    downloads='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/downloads.svg)]'
+              '(https://anaconda.org/nsls2forge/{name})')
+
+row_string = '''|[{name}](https://github.com/nsls-ii-forge/{name}-feedstock)|{build}|{health}
+|{cf_version} <br/> {nsls_version}|{downloads}|\n'''
+description = '''# Project Management
+Releases, Installers, Specs, and more!
+'''
+header = '''# {} Packages Build status\n
+| Repo | Build | Health | CF Version <br/> NSLS Version | Downloads|
+|:-------:|:-----:|:------:|:------:|:------:|
+'''
+
+out = description
+name = 'Feedstock'
+pkgs = sorted(get_all_feedstocks(organization='nsls-ii-forge'))
+out += header.format(name)
+for pkg in pkgs:
+    tmp = row_string.format(**main_format, name=pkg)
+    out += tmp.format(name=pkg)
+# with open('../README.md', 'w') as f:
+#     f.write(out)

--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -25,26 +25,26 @@ def create_dashboard(names=None, write_to='README.md'):
     # TODO: Azure Pipeline direct pipeline link
     # TODO: Add codecov badge if available
     main_format = dict(
-      build='[![Build Status](https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/{name}-feedstock)]'
+      build='[![Not Found](https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/{name}-feedstock)]'
             '(https://dev.azure.com/nsls2forge/nsls2forge/_build)',
-      health='[![Code Health](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master/'
+      health='[![Not Found](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master/'
              'landscape.svg?style=flat)](https://landscape.io/github/nsls-ii-forge/{name}-feedstock/master)',
-      cf_version='[![Anaconda-Server Badge](https://anaconda.org/conda-forge/{name}/badges/version.svg)]'
+      cf_version='[![Not Found](https://anaconda.org/conda-forge/{name}/badges/version.svg)]'
                  '(https://anaconda.org/conda-forge/{name})',
-      nsls_version='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/version.svg)]'
+      nsls_version='[![Not Found](https://anaconda.org/nsls2forge/{name}/badges/version.svg)]'
                    '(https://anaconda.org/nsls2forge/{name})',
-      downloads='[![Anaconda-Server Badge](https://anaconda.org/nsls2forge/{name}/badges/downloads.svg)]'
+      defaults_version='[![Not Found](https://anaconda.org/anaconda/{name}/badges/version.svg)]'
+                       '(https://anaconda.org/anaconda/{name})',
+      pypi_version='[![Not Found](https://img.shields.io/pypi/v/{name})](https://pypi.org/project/{name}/)',
+      downloads='[![Not Found](https://anaconda.org/nsls2forge/{name}/badges/downloads.svg)]'
                 '(https://anaconda.org/nsls2forge/{name})')
 
-    row_string = '''|[{name}](https://github.com/nsls-ii-forge/{name}-feedstock)|{build}|{health}
-    |{cf_version} <br/> {nsls_version}|{downloads}|\n'''
-    description = '''# Project Management
-    Releases, Installers, Specs, and more!
-    '''
-    header = '''# Feedstock Packages Build status\n
-    | Repo | Build | Health | CF Version <br/> NSLS Version | Downloads|
-    |:-------:|:-----:|:------:|:------:|:------:|
-    '''
+    row_string = ('|[{name}](https://github.com/nsls-ii-forge/{name}-feedstock)|{build} <br/> {health}'
+    '|{nsls_version} <br/> {pypi_version} <br/> {defaults_version} <br/> {cf_version}|{downloads}|\n')
+    description = '''# Project Management\nReleases, Installers, Specs, and more!\n'''
+    header = ('# Feedstock Packages Build Status\n\n'
+    '| Repo | Build <br/> Health | nsls2forge <br/> PyPI <br/> defaults <br/> conda-forge <br/> Versions | Downloads|\n'
+    '|:-------:|:-----------:|:---------------:|:--------------:|\n')
 
     out = description
     if names is None:

--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -40,11 +40,12 @@ def create_dashboard(names=None, write_to='README.md'):
                 '(https://anaconda.org/nsls2forge/{name})')
 
     row_string = ('|[{name}](https://github.com/nsls-ii-forge/{name}-feedstock)|{build} <br/> {health}'
-    '|{nsls_version} <br/> {pypi_version} <br/> {defaults_version} <br/> {cf_version}|{downloads}|\n')
+                  '|{nsls_version} <br/> {pypi_version} <br/> {defaults_version} <br/> '
+                  '{cf_version}|{downloads}|\n')
     description = '''# Project Management\nReleases, Installers, Specs, and more!\n'''
     header = ('# Feedstock Packages Build Status\n\n'
-    '| Repo | Build <br/> Health | nsls2forge <br/> PyPI <br/> defaults <br/> conda-forge <br/> Versions | Downloads|\n'
-    '|:-------:|:-----------:|:---------------:|:--------------:|\n')
+              '| Repo | Build <br/> Health | nsls2forge <br/> PyPI <br/> defaults <br/> conda-forge <br/>'
+              ' Versions | Downloads|\n|:-------:|:-----------:|:---------------:|:--------------:|\n')
 
     out = description
     if names is None:

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'console_scripts': [
             'check-results = nsls2forge_utils.cli:check_results',
             'all-feedstocks = nsls2forge_utils.cli:all_feedstocks',
+            'dashboard = nsls2forge_utils.cli:dashboard',
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
- Added script to generate the dashboard found at https://github.com/nsls-ii-forge/project-management.
- Added an entry point called `dashboard` that will execute this script with some options.
- There is no integration with the other repository, however. You will need to move the generated file and push it to the `project_management` repo when regenerating the dashboard with new feedstocks.