### PR TITLE
added flag for archived feedstocks

### DIFF
--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -15,7 +15,8 @@ from nsls2forge_utils.io import _write_list_to_file, read_file_to_list
 logger = logging.getLogger(__name__)
 
 
-def get_all_feedstocks_from_github(organization=None, username=None, token=None):
+def get_all_feedstocks_from_github(organization=None, username=None, token=None,
+                                   archived=False):
     '''
     Gets all public feedstock repository names from the GitHub organization
     (e.g. nsls-ii-forge).
@@ -30,6 +31,9 @@ def get_all_feedstocks_from_github(organization=None, username=None, token=None)
     password: str, optional
         Password of user on GitHub for authentication.
         Uses value from ~/.netrc if not specified.
+    archived: bool, optional
+        Includes archived feedstocks in returned list
+        when set to True.
 
     Returns
     -------
@@ -49,6 +53,8 @@ def get_all_feedstocks_from_github(organization=None, username=None, token=None)
     names = []
     try:
         for repo in repos:
+            if repo.archived and not archived:
+                continue
             name = repo.name
             if name.endswith("-feedstock"):
                 name = name.split("-feedstock")[0]
@@ -129,7 +135,8 @@ def _list_all_handle_args(args):
                                organization=args.organization,
                                username=args.username,
                                token=args.token,
-                               filepath=args.filepath)
+                               filepath=args.filepath,
+                               archived=args.archived)
     names = sorted(names)
     if args.write:
         _write_list_to_file(names, args.filepath, sort=False)

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -97,6 +97,12 @@ def all_feedstocks():
     list_parser.add_argument('-c', '--cached', dest='cached',
                              action='store_true',
                              help=('read the names of feedstocks from the cache'))
+
+    list_parser.add_argument('-a', '--archived', dest='archived',
+                             action='store_true',
+                             help=('Includes archived feedstocks in returned list '
+                                   'when set to True.'))
+
     # Set function to handle arguments
     list_parser.set_defaults(func=_list_all_handle_args)
 


### PR DESCRIPTION
Added a flag to entry point `all-feedstocks list` that allows user to include archived feedstocks when getting the names of feedstocks from GitHub. 

Default behavior now ignores archived feedstocks from being included in the list.