### PR TITLE
update graph with versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ pr_status/*
 status/*
 feedstocks/*
 versions/*
+dask-worker-space/*
 coverage.xml
 .coverage.*
 miniconda.sh

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ pr_json/*
 pr_status/*
 status/*
 feedstocks/*
+versions/*
 coverage.xml
 .coverage.*
 miniconda.sh

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -4,7 +4,11 @@ import sys
 from .check_results import check_conda_channels, check_package_version
 from .all_feedstocks import _list_all_handle_args, _clone_all_handle_args
 from .dashboard import create_dashboard
-from .graph_utils import _make_graph_handle_args, _query_graph_handle_args
+from .graph_utils import (
+    _make_graph_handle_args,
+    _query_graph_handle_args,
+    _update_handle_args
+)
 
 
 def check_results():
@@ -197,6 +201,16 @@ def graph_utils():
                              help=('Type of query: depends_on, depends_of'))
 
     info_parser.set_defaults(func=_query_graph_handle_args)
+
+    update_parser = subparsers.add_parser('update',
+                                          help=('Update package versions in graph from '
+                                                'various sources'))
+
+    update_parser.add_argument('-f', '--filepath', dest='filepath',
+                               default='graph.json', type=str,
+                               help=('Path to JSON file where the graph is stored'))
+
+    update_parser.set_defaults(func=_update_handle_args)
 
     args = parser.parse_args()
 

--- a/nsls2forge_utils/graph_utils.py
+++ b/nsls2forge_utils/graph_utils.py
@@ -258,6 +258,23 @@ def make_graph(names, organization, gx=None):
     return gx
 
 
+def update_versions_in_graph(gx):
+    '''
+    Updates the version numbers for packages in the graph if new
+    versions are available
+    Stores result in directory ./versions/
+    Parameters
+    ----------
+    gx: nx.DiGraph
+        Dependency graph to be updated
+    '''
+    from conda_forge_tick.new_update_versions import update_upstream_versions
+    from conda_forge_tick.make_graph import update_nodes_with_new_versions
+    os.makedirs("versions", exist_ok=True)
+    update_upstream_versions(gx)
+    update_nodes_with_new_versions(gx)
+
+
 def list_dependencies_on(gx, pkg_name):
     '''
     Provides a list of package names that require pkg_name to be installed
@@ -337,3 +354,11 @@ def _query_graph_handle_args(args):
         print(f'Total: {len(dependencies)}')
     else:
         print(f'Unknown query type: {args.query}')
+
+
+def _update_handle_args(args):
+    from conda_forge_tick.utils import load_graph
+    if args.filepath != 'graph.json':
+        copyfile(args.filepath, 'graph.json')
+    gx = load_graph()
+    update_versions_in_graph(gx)


### PR DESCRIPTION
This should be merged into `make-graph` branch, then reviewed there.

This adds the functionality of updating the version numbers of packages from their sources (PyPI, GitHub, etc)

It makes heavy use of the `conda-forge-tick` library, which is not an official python package (as of right now).