### PR TITLE
All feedstocks tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
     echo "machine github.com" > $HOME/.netrc
     echo "login $GITHUB_USERNAME" >> $HOME/.netrc
     echo "password $GITHUB_TOKEN" >> $HOME/.netrc
+    chmod og-rw $HOME/.netrc
 
 install:
   - conda create -n testenv python=$TRAVIS_PYTHON_VERSION -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ before_install:
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-${arch}-x86_64.sh -O miniconda.sh
     bash miniconda.sh -b -p ~/mc
     source ~/mc/etc/profile.d/conda.sh
+  - |
+    echo "machine github.com" > $HOME/.netrc
+    echo "login $GITHUB_USERNAME" >> $HOME/.netrc
+    echo "password $GITHUB_TOKEN" >> $HOME/.netrc
 
 install:
   - conda create -n testenv python=$TRAVIS_PYTHON_VERSION -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     echo "machine github.com" > $HOME/.netrc
     echo "login $GITHUB_USERNAME" >> $HOME/.netrc
     echo "password $GITHUB_TOKEN" >> $HOME/.netrc
-    chmod og-rw $HOME/.netrc
+    chmod -v go-rw $HOME/.netrc
 
 install:
   - conda create -n testenv python=$TRAVIS_PYTHON_VERSION -y

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -150,6 +150,11 @@ def all_feedstocks_info(feedstocks_dir='./feedstocks/'):
     ----------
     feedstocks_dir: str, optional
         Directory where cloned feedstocks are. Default is './feedstocks/'.
+
+    Returns
+    -------
+    df: pd.DataFrame
+        Table with name, branch, changed, and version info
     '''
     all_feedstocks = get_all_feedstocks(cached=True, feedstocks_dir=feedstocks_dir)
     info = []
@@ -176,6 +181,7 @@ def all_feedstocks_info(feedstocks_dir='./feedstocks/'):
     columns = ['Name', 'Branch', 'Changed?', 'Version']
     df = pd.DataFrame(info, columns=columns)
     print(tabulate(df, headers=df.columns))
+    return df
 
 
 def _info_handle_args(args):

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_all_feedstocks_from_github(organization=None, username=None, token=None,
-                                   archived=False):
+                                   include_archived=False):
     '''
     Gets all public feedstock repository names from the GitHub organization
     (e.g. nsls-ii-forge).
@@ -42,7 +42,7 @@ def get_all_feedstocks_from_github(organization=None, username=None, token=None,
     password: str, optional
         Password of user on GitHub for authentication.
         Uses value from ~/.netrc if not specified.
-    archived: bool, optional
+    include_archived: bool, optional
         Includes archived feedstocks in returned list
         when set to True.
 
@@ -64,7 +64,7 @@ def get_all_feedstocks_from_github(organization=None, username=None, token=None,
     try:
         repos = org.get_repos()
         for repo in repos:
-            if repo.archived and not archived:
+            if repo.archived and not include_archived:
                 continue
             name = repo.name
             if name.endswith("-feedstock"):
@@ -203,7 +203,7 @@ def _list_all_handle_args(args):
                                username=args.username,
                                token=args.token,
                                filepath=args.filepath,
-                               archived=args.archived)
+                               include_archived=args.archived)
     names = sorted(names)
     if args.write:
         _write_list_to_file(names, args.filepath, sort=False)

--- a/nsls2forge_utils/all_feedstocks.py
+++ b/nsls2forge_utils/all_feedstocks.py
@@ -203,7 +203,7 @@ def _list_all_handle_args(args):
                                username=args.username,
                                token=args.token,
                                filepath=args.filepath,
-                               include_archived=args.archived)
+                               include_archived=args.include_archived)
     names = sorted(names)
     if args.write:
         _write_list_to_file(names, args.filepath, sort=False)

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -109,7 +109,7 @@ def all_feedstocks():
                              action='store_true',
                              help=('read the names of feedstocks from the cache'))
 
-    list_parser.add_argument('-a', '--archived', dest='archived',
+    list_parser.add_argument('-a', '--include-archived', dest='archived',
                              action='store_true',
                              help=('Includes archived feedstocks in returned list '
                                    'when set to True.'))

--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -109,7 +109,7 @@ def all_feedstocks():
                              action='store_true',
                              help=('read the names of feedstocks from the cache'))
 
-    list_parser.add_argument('-a', '--include-archived', dest='archived',
+    list_parser.add_argument('-a', '--include-archived', dest='include_archived',
                              action='store_true',
                              help=('Includes archived feedstocks in returned list '
                                    'when set to True.'))

--- a/nsls2forge_utils/tests/test_all_feedstocks.py
+++ b/nsls2forge_utils/tests/test_all_feedstocks.py
@@ -14,7 +14,7 @@ def test_all_feedstocks_from_github():
     assert names is None
     names = get_all_feedstocks_from_github(organization='nsls-ii-forge')
     include_archived = get_all_feedstocks_from_github(organization='nsls-ii-forge',
-                                                      archived=True)
+                                                      include_archived=True)
     size_names = len(names)
     size_include_archived = len(include_archived)
     assert size_include_archived >= size_names

--- a/nsls2forge_utils/tests/test_all_feedstocks.py
+++ b/nsls2forge_utils/tests/test_all_feedstocks.py
@@ -1,49 +1,54 @@
 import os
+import shutil
+import subprocess
 
 from nsls2forge_utils.all_feedstocks import (
-	get_all_feedstocks_from_github,
-	get_all_feedstocks,
-	clone_all_feedstocks,
-	all_feedstocks_info
+    get_all_feedstocks_from_github,
+    get_all_feedstocks,
+    all_feedstocks_info
 )
 
+
 def test_all_feedstocks_from_github():
-	names = get_all_feedstocks_from_github()
-	assert names is None
-	names = get_all_feedstocks_from_github(organization='nsls-ii-forge')
-	archived_names = get_all_feedstocks_from_github(organization='nsls-ii-forge',
-													archived=True)
-	size_names = len(names)
-	size_archived = len(archived_names)
-	assert size_archived >= size_names
-	assert size_names > 0
-	assert size_archived > 0
+    names = get_all_feedstocks_from_github()
+    assert names is None
+    names = get_all_feedstocks_from_github(organization='nsls-ii-forge')
+    archived_names = get_all_feedstocks_from_github(organization='nsls-ii-forge',
+                                                    archived=True)
+    size_names = len(names)
+    size_archived = len(archived_names)
+    assert size_archived >= size_names
+    assert size_names > 0
+    assert size_archived > 0
 
 
 def test_all_feedstocks():
-	names = get_all_feedstocks()
-	assert names is None
-	with open('names.txt', 'w') as f:
-		f.write('event-model\n')
-		f.write('bluesky')
-	names = get_all_feedstocks(cached=True)
-	assert 'event-model' in names
-	assert 'bluesky' in names
-	assert len(names) == 2
-	os.remove('names.txt')
-	os.makedirs('./feedstocks/event-model-feedstock', exist_ok=True)
-	os.makedirs('./feedstocks/bluesky-feedstock', exist_ok=True)
-	names = get_all_feedstocks(cached=True, feedstocks_dir='./feedstocks/')
-	assert 'event-model' in names
-	assert 'bluesky' in names
-	assert len(names) == 2
-	os.rmdir('./feedstocks/event-model-feedstock')
-	os.rmdir('./feedstocks/bluesky-feedstock')
-
-
-def test_clone_all_feedstocks():
-	pass
+    names = get_all_feedstocks()
+    assert names is None
+    with open('names.txt', 'w') as f:
+        f.write('event-model\n')
+        f.write('bluesky')
+    names = get_all_feedstocks(cached=True)
+    assert 'event-model' in names
+    assert 'bluesky' in names
+    assert len(names) == 2
+    os.remove('names.txt')
+    os.makedirs('./test_feedstocks/event-model-feedstock', exist_ok=True)
+    os.makedirs('./test_feedstocks/bluesky-feedstock', exist_ok=True)
+    names = get_all_feedstocks(cached=True, feedstocks_dir='./test_feedstocks/')
+    assert 'event-model' in names
+    assert 'bluesky' in names
+    assert len(names) == 2
+    shutil.rmtree('./test_feedstocks')
 
 
 def test_all_feedstocks_info():
-	pass
+    cmd = ('git clone --depth 1 https://github.com/nsls-ii-forge/event-model-feedstock.git '
+           './test_feedstocks/event-model-feedstock')
+    subprocess.run(cmd, shell=True)
+    df = all_feedstocks_info(feedstocks_dir='./test_feedstocks/')
+    assert len(df.index) == 1
+    assert df.size == 4
+    assert list(df.columns) == ['Name', 'Branch', 'Changed?', 'Version']
+    assert df['Name'].iloc[0] == 'event-model-feedstock'
+    shutil.rmtree('./test_feedstocks')

--- a/nsls2forge_utils/tests/test_all_feedstocks.py
+++ b/nsls2forge_utils/tests/test_all_feedstocks.py
@@ -13,13 +13,13 @@ def test_all_feedstocks_from_github():
     names = get_all_feedstocks_from_github()
     assert names is None
     names = get_all_feedstocks_from_github(organization='nsls-ii-forge')
-    archived_names = get_all_feedstocks_from_github(organization='nsls-ii-forge',
-                                                    archived=True)
+    include_archived = get_all_feedstocks_from_github(organization='nsls-ii-forge',
+                                                      archived=True)
     size_names = len(names)
-    size_archived = len(archived_names)
-    assert size_archived >= size_names
+    size_include_archived = len(include_archived)
+    assert size_include_archived >= size_names
     assert size_names > 0
-    assert size_archived > 0
+    assert size_include_archived > 0
 
 
 def test_all_feedstocks():

--- a/nsls2forge_utils/tests/test_all_feedstocks.py
+++ b/nsls2forge_utils/tests/test_all_feedstocks.py
@@ -1,0 +1,49 @@
+import os
+
+from nsls2forge_utils.all_feedstocks import (
+	get_all_feedstocks_from_github,
+	get_all_feedstocks,
+	clone_all_feedstocks,
+	all_feedstocks_info
+)
+
+def test_all_feedstocks_from_github():
+	names = get_all_feedstocks_from_github()
+	assert names is None
+	names = get_all_feedstocks_from_github(organization='nsls-ii-forge')
+	archived_names = get_all_feedstocks_from_github(organization='nsls-ii-forge',
+													archived=True)
+	size_names = len(names)
+	size_archived = len(archived_names)
+	assert size_archived >= size_names
+	assert size_names > 0
+	assert size_archived > 0
+
+
+def test_all_feedstocks():
+	names = get_all_feedstocks()
+	assert names is None
+	with open('names.txt', 'w') as f:
+		f.write('event-model\n')
+		f.write('bluesky')
+	names = get_all_feedstocks(cached=True)
+	assert 'event-model' in names
+	assert 'bluesky' in names
+	assert len(names) == 2
+	os.remove('names.txt')
+	os.makedirs('./feedstocks/event-model-feedstock', exist_ok=True)
+	os.makedirs('./feedstocks/bluesky-feedstock', exist_ok=True)
+	names = get_all_feedstocks(cached=True, feedstocks_dir='./feedstocks/')
+	assert 'event-model' in names
+	assert 'bluesky' in names
+	assert len(names) == 2
+	os.rmdir('./feedstocks/event-model-feedstock')
+	os.rmdir('./feedstocks/bluesky-feedstock')
+
+
+def test_clone_all_feedstocks():
+	pass
+
+
+def test_all_feedstocks_info():
+	pass


### PR DESCRIPTION
Created tests for some utilities within `all-feedstocks`. 

I was debating including our `all-feedstocks clone` utility and decided against it since it has to handle the import of `conda_smithy`, needs `~/.condarc` setup, and takes a long time to run.

Let me know if I can extend the tests in any way.

This reopens #29 since it was force closed for some reason.