### PR TITLE
param MAX_WORKERS

### DIFF
--- a/nsls2forge_utils/cli.py
+++ b/nsls2forge_utils/cli.py
@@ -246,6 +246,10 @@ def graph_utils():
                              help=('Specify to create graph sequentially instead of in '
                                    'parallel'))
 
+    make_parser.add_argument('-m', '--max-workers', dest='max_workers',
+                             default=20, type=int,
+                             help=('Maximum number of workers in process pool to build graph'))
+
     make_parser.set_defaults(func=_make_graph_handle_args)
 
     info_parser = subparsers.add_parser('info',

--- a/nsls2forge_utils/graph_utils.py
+++ b/nsls2forge_utils/graph_utils.py
@@ -21,6 +21,7 @@ from .io import _fetch_file
 logger = logging.getLogger(__name__)
 pin_sep_pat = re.compile(r" |>|<|=|\[")
 
+MAX_WORKERS = 20
 NUM_GITHUB_THREADS = 2
 DEBUG = False
 
@@ -75,7 +76,7 @@ def _build_graph_process_pool(gx, names, new_names, organization):
         Name of GitHub organization containing feedstock repos.
     '''
     from conda_forge_tick.utils import executor
-    with executor("thread", max_workers=20) as pool:
+    with executor("thread", max_workers=MAX_WORKERS) as pool:
         futures = {
             pool.submit(get_attrs, name, organization): name
             for name in names
@@ -288,6 +289,8 @@ def _make_graph_handle_args(args):
     # get a list of all feedstocks from nsls-ii-forge
     global DEBUG
     DEBUG = args.debug
+    global MAX_WORKERS
+    MAX_WORKERS = args.max_workers
     organization = args.organization
     names = get_all_feedstocks(cached=args.cached, filepath=args.filepath,
                                organization=organization)


### PR DESCRIPTION
Adds the ability to select the maximum number of workers for the process pool when building the graph. There is still the option to build the graph sequentially using `-d` or `--debug`.

This allows the user to build the graph with the option `-m` or `--max-workers`.

Example:

`graph-utils make -o nsls-ii-forge -m 5`

This will build the graph with a maximum of 5 workers in the process pool.

Closes #32 