### PR TITLE
Fix for allowing bot to run with fork=False

### DIFF
--- a/nsls2forge_utils/auto_tick.py
+++ b/nsls2forge_utils/auto_tick.py
@@ -160,7 +160,7 @@ def bot_pr_body(self, feedstock_ctx):
 
 
 def run(feedstock_ctx, migrator, protocol='ssh', pull_request=True,
-        rerender=True, fork=True, organization='nsls-ii-forge', **kwargs):
+        rerender=True, fork=False, organization='nsls-ii-forge', **kwargs):
     """
     For a given feedstock and migration run the migration
 

--- a/nsls2forge_utils/git_utils.py
+++ b/nsls2forge_utils/git_utils.py
@@ -45,7 +45,7 @@ def feedstock_url(fctx, organization='nsls-ii-forge', protocol="ssh"):
 
 
 def get_repo(ctx, fctx, branch, organization='nsls-ii-forge', feedstock=None,
-             protocol="ssh", pull_request=True, fork=True):
+             protocol="ssh", pull_request=True, fork=False):
     """
     Get the feedstock repo from the specified GitHub organization
 


### PR DESCRIPTION
I ended up just changing the flags back to False by default.

It seems that the previous change in master from:
```
origin = fork_url(upstream, ctx.github_username)
```
to
```
if fork:
    origin = fork_url(upstream, ctx.github_username)
else:
    origin = upstream
```
does the trick. I tested it locally with the `asks` package but did not allow the bot to submit a PR.

Closes #41 