### PR TITLE
Fixed issue with pushing repo assuming fork=True

### DIFF
--- a/nsls2forge_utils/auto_tick.py
+++ b/nsls2forge_utils/auto_tick.py
@@ -310,6 +310,7 @@ def run(feedstock_ctx, migrator, protocol='ssh', pull_request=True,
                 title=migrator.pr_title(feedstock_ctx),
                 head=f"{migrator.ctx.github_username}:{branch_name}",
                 branch=branch_name,
+                fork=fork,
                 organization=organization
             )
 
@@ -327,6 +328,8 @@ def run(feedstock_ctx, migrator, protocol='ssh', pull_request=True,
             os.path.join(migrator.ctx.session.prjson_dir, str(pr_json["id"]) + ".json"),
         )
         ljpr.update(**pr_json)
+    else:
+        ljpr = None
     # If we've gotten this far then the node is good
     feedstock_ctx.attrs["bad"] = False
     logger.info("Removing feedstock dir")

--- a/nsls2forge_utils/git_utils.py
+++ b/nsls2forge_utils/git_utils.py
@@ -106,7 +106,7 @@ def get_repo(ctx, fctx, branch, organization='nsls-ii-forge', feedstock=None,
 
 
 def push_repo(session_ctx, fctx, feedstock_dir, body, repo, title, head, branch,
-              organization='nsls-ii-forge'):
+              fork=False, organization='nsls-ii-forge'):
     """
     Push a repo up to github
 
@@ -127,7 +127,10 @@ def push_repo(session_ctx, fctx, feedstock_dir, body, repo, title, head, branch,
         # Setup push from doctr
         # Copyright (c) 2016 Aaron Meurer, Gil Forsyth
         token = session_ctx.github_password
-        deploy_repo = f'{session_ctx.github_username}/{fctx.feedstock_name}-feedstock'
+        if fork:
+            deploy_repo = f'{session_ctx.github_username}/{fctx.feedstock_name}-feedstock'
+        else:
+            deploy_repo = f'{organization}/{fctx.feedstock_name}-feedstock'
         if session_ctx.dry_run:
             repo_url = f"https://github.com/{deploy_repo}.git"
             print(f"dry run: adding remote and pushing up branch for {repo_url}")


### PR DESCRIPTION
Added fork flag to `git_utils.push_repo`.

It previously assumed that fork was set to True for all previous steps.