### PR TITLE
Fix parsing urls

### DIFF
--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -4,7 +4,7 @@ https://github.com/xpdAcq/mission-control/blob/master/tools/update_readme.py
 This version was not importable so the
 functions had to be re-implemented here.
 """
-from urllib.parse import urlparse, ParseResult, ParseResultBytes
+from urllib.parse import urlparse, ParseResultBytes
 
 from .all_feedstocks import get_all_feedstocks
 from .meta_utils import get_attribute

--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -12,7 +12,7 @@ from .meta_utils import get_attribute
 
 def _extract_github_org_and_repo_from_url(url):
     url = urlparse(url)
-    if url is not None and url.netloc == 'github.com':
+    if url is not None and 'github.com' in url.netloc:
         path = url.path.strip('/').split('/')
         if len(path) == 0:
             return '', ''

--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -4,22 +4,24 @@ https://github.com/xpdAcq/mission-control/blob/master/tools/update_readme.py
 This version was not importable so the
 functions had to be re-implemented here.
 """
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult, ParseResultBytes
 
 from .all_feedstocks import get_all_feedstocks
 from .meta_utils import get_attribute
 
 
 def _extract_github_org_and_repo_from_url(url):
-    url = urlparse(url)
-    if url and 'github.com' in url.netloc:
-        path = url.path.strip('/').split('/')
+    url_obj = urlparse(url)
+    if isinstance(url_obj, ParseResultBytes):
+        url_obj = url_obj.decode()
+    if url and 'github.com' in url_obj.netloc:
+        path = url_obj.path.strip('/').split('/')
         if len(path) == 0:
             return '', ''
         elif len(path) == 1:
             path.append('')
         return path[-2], path[-1]
-    return '', ''
+    return ('', '')
 
 
 def _extract_github_org_and_repo(pkg, feedstock_org='nsls-ii-forge'):

--- a/nsls2forge_utils/dashboard.py
+++ b/nsls2forge_utils/dashboard.py
@@ -12,7 +12,7 @@ from .meta_utils import get_attribute
 
 def _extract_github_org_and_repo_from_url(url):
     url = urlparse(url)
-    if url is not None and 'github.com' in url.netloc:
+    if url and 'github.com' in url.netloc:
         path = url.path.strip('/').split('/')
         if len(path) == 0:
             return '', ''
@@ -22,13 +22,13 @@ def _extract_github_org_and_repo_from_url(url):
     return '', ''
 
 
-def _extract_github_org_and_repo(pkg):
+def _extract_github_org_and_repo(pkg, feedstock_org='nsls-ii-forge'):
     # get org from home url
-    home_str = get_attribute('about home', pkg, 'nsls-ii-forge')
+    home_str = get_attribute('about home', pkg, feedstock_org)
     org, repo = _extract_github_org_and_repo_from_url(home_str)
     # if home url failed try dev_url
     if org == '':
-        dev_url = get_attribute('about dev_url', pkg, 'nsls-ii-forge')
+        dev_url = get_attribute('about dev_url', pkg, feedstock_org)
         org, repo = _extract_github_org_and_repo_from_url(dev_url)
     return org, repo
 

--- a/nsls2forge_utils/tests/test_extract_github_org_and_repo_from_url.py
+++ b/nsls2forge_utils/tests/test_extract_github_org_and_repo_from_url.py
@@ -1,6 +1,5 @@
 import pytest
 
-from nsls2forge_utils.meta_utils import get_attribute
 from nsls2forge_utils.dashboard import (_extract_github_org_and_repo,
                                         _extract_github_org_and_repo_from_url)
 

--- a/nsls2forge_utils/tests/test_extract_github_org_and_repo_from_url.py
+++ b/nsls2forge_utils/tests/test_extract_github_org_and_repo_from_url.py
@@ -1,0 +1,23 @@
+import pytest
+
+from nsls2forge_utils.meta_utils import get_attribute
+from nsls2forge_utils.dashboard import (_extract_github_org_and_repo,
+                                        _extract_github_org_and_repo_from_url)
+
+
+def test_extract_org_and_repo():
+    (org, repo) = _extract_github_org_and_repo('qtmodern')
+    assert (org, repo) == ('gmarull', 'qtmodern')
+
+
+@pytest.mark.parametrize(
+    'url,expected',
+    [('https://www.github.com/gmarull/qtmodern', ('gmarull', 'qtmodern')),
+     ('http://www.github.com/gmarull/qtmodern', ('gmarull', 'qtmodern')),
+     ('https://github.com/gmarull/qtmodern', ('gmarull', 'qtmodern')),
+     ('something', ('', ''))
+     ]
+)
+def test_extract_org_and_repo_from_url(url, expected):
+    org, repo = _extract_github_org_and_repo_from_url(url)
+    assert (org, repo) == expected


### PR DESCRIPTION
It was failing on parsing [`https://www.github.com/gmarull/qtmodern`](https://github.com/nsls-ii-forge/qtmodern-feedstock/blob/8b37fc839bf6eed1b172f0b475a5bb935eb51c13/recipe/meta.yaml#L34).